### PR TITLE
Initial commit of with_env handler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,9 @@ RUN conda config --set auto_update_conda false \
         ${CONDA_PACKAGES} \
     && chown -R jenkins: ${OPT} ${HOME}
 
+# Inject custom handlers
+ADD with_env /usr/local/bin
+
 WORKDIR ${HOME}
 
 EXPOSE 22

--- a/with_env
+++ b/with_env
@@ -1,0 +1,23 @@
+#!/bin/bash
+set +x
+environ=base
+commands=()
+
+while [[ $# > 0 ]]
+do
+    key="$1"
+    case $key in
+        -n|--name)
+            environ="$2"
+            shift 2
+            ;;
+        *)
+            commands+=("$1")
+            shift
+            ;;
+    esac
+done
+
+source activate $environ
+${commands[@]}
+exit $?


### PR DESCRIPTION
Make it a little easier to run one-liners in conda environments:

```
$ conda create -y -n whatever python=3.6 something
$ with_env -n whatever something --args will --be parsed --just fine
```