### PR TITLE
Quote command execution

### DIFF
--- a/with_env
+++ b/with_env
@@ -19,5 +19,5 @@ do
 done
 
 source activate $environ
-${commands[@]}
+"${commands[@]}"
 exit $?


### PR DESCRIPTION
Fixes quote escaping issues caused via simple commands like:

```
[linux/sdist] + with_env -n base python -c 'import os'
[linux/sdist]   File "<string>", line 1
[linux/sdist]     import
[linux/sdist]          ^
[linux/sdist] SyntaxError: invalid syntax
```